### PR TITLE
To use composer instead of submodule for installation

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "vendor/bugsnag-php"]
-	path = vendor/bugsnag-php
-	url = https://github.com/bugsnag/bugsnag-php.git

--- a/README.md
+++ b/README.md
@@ -7,7 +7,34 @@ Tested to work with both Silverstripe 2.4 and 3.x applications.
 
 ## Installation ##
 
-Currently, the easiest way is to import the repository as a submodule into your project.
+The recommended way is using [Composer](http://getcomposer.org/). 
+
+Add this repository to your project's `composer.json` file
+
+```json
+"repositories": [
+{
+	"type": "vcs",
+	"url": "https://github.com/evolution7/silverstripe-bugsnag-logger"
+}
+],
+"require": {
+	"evolution7/bugsnag-logger": "dev-master"
+}
+```
+
+If there isn't a `composer.lock` file already, you can simply run
+```shell
+$ composer install
+```
+Otherwise, to install this library only, run the following command to avoid updating other dependencies
+```shell
+$ composer update evolution7/bugsnag-logger
+```
+
+The required [bugsnag-php](https://github.com/bugsnag/bugsnag-php) library should also be installed into `vendor/bugsnag/bugsnag/` under your project root directory. You should verify if the bugsnag autoloader has been correctly included by looking at `bugsnag-logger/code/BugsnagLogger.php`.
+
+Alternatively, you can import the repository as a submodule into your project if you choose not to use composer.
 
 * `git submodule add https://github.com/evolution7/silverstripe-bugsnag-logger bugsnag-logger`
 * `git submodule update --recursive --init`

--- a/code/BugsnagLogger.php
+++ b/code/BugsnagLogger.php
@@ -8,7 +8,7 @@
  * file that was distributed with this source code.
  */
 require_once 'Zend/Log/Writer/Abstract.php';
-require_once __DIR__ . '/../vendor/bugsnag-php/src/Bugsnag/Autoload.php';
+require_once __DIR__ . '/../../vendor/bugsnag/bugsnag/src/Bugsnag/Autoload.php';
 
 /**
  * Sends an error message to Bugsnag.

--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
     "require": {
         "php": ">=5.3.2",
         "bugsnag/bugsnag": "2.*",
-        "silverstripe/cms": "~3.0"
+        "silverstripe/cms": ">=2.4"
     },
     "target-dir": "bugsnag-logger"
 }

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,14 @@
+{
+    "name": "evolution7/bugsnag-logger",
+    "type": "silverstripe-module",
+    "description": "Bugsnag error reporting integration for Silverstripe",
+    "keywords": ["silverstripe", "bugsnag", "exceptions", "errors", "logging", "tracking"],
+    "homepage": "https://github.com/evolution7/silverstripe-bugsnag-logger",
+    "license": "MIT",
+    "require": {
+        "php": ">=5.3.2",
+        "bugsnag/bugsnag": "2.*",
+        "silverstripe/cms": "~3.0"
+    },
+    "target-dir": "bugsnag-logger"
+}


### PR DESCRIPTION
@ArjenSchwarz I changed the require path for bugsnag-php in `BugsnagLogger.php` anyway as that should be the default path if you run `composer install` from your project root. See the updated README for more info.
